### PR TITLE
Fix priority ignore when 0

### DIFF
--- a/xml-sitemap.php
+++ b/xml-sitemap.php
@@ -151,7 +151,7 @@ class Joost_XML_Sitemap_PHP {
 			if ( ! empty( $this->changefreq ) ) {
 				$output .= "\t" . '<changefreq>' . $this->changefreq . '</changefreq>' . PHP_EOL;
 			}
-			if ( $this->priority !== 0 && $this->priority <= 1 ) {
+			if ( $this->priority != 0 && $this->priority <= 1 ) {
 				$output .= "\t" . '<priority>' . $this->priority . '</priority>' . PHP_EOL;
 			}
 			$output .= '</url>' . PHP_EOL;

--- a/xml-sitemap.php
+++ b/xml-sitemap.php
@@ -151,7 +151,7 @@ class Joost_XML_Sitemap_PHP {
 			if ( ! empty( $this->changefreq ) ) {
 				$output .= "\t" . '<changefreq>' . $this->changefreq . '</changefreq>' . PHP_EOL;
 			}
-			if ( $this->priority != 0 && $this->priority <= 1 ) {
+			if ( $this->priority > 0 && $this->priority <= 1 ) {
 				$output .= "\t" . '<priority>' . $this->priority . '</priority>' . PHP_EOL;
 			}
 			$output .= '</url>' . PHP_EOL;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

Fixed the issue that `priority` is still output when it is `0`.

## Relevant technical choices:

The operator `!==` will also compare the types. `$priority` is of type float and `0` is implicitly int. Therefore, no matter what the `$priority` value is, it will return `TRUE` because of the different types. Need to change `0` to `0.0`, or more correctly, change `!==` to `!=` which have implicit type conversion.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

Test on php7.4.33 and php 8.2.18.